### PR TITLE
Fixed resolution chart dates to show end of the month instead of start of the month

### DIFF
--- a/themes/doi-theme/layouts/partials/numbers-graphs-js.html
+++ b/themes/doi-theme/layouts/partials/numbers-graphs-js.html
@@ -190,9 +190,7 @@
             both.push([key, monthlyResolutions[key].resolutions ]) ; 
             
             //console.log('adding row');
-            datestring = key + "-01";
-            var dateobj = new Date(datestring);
-            //console.log("datestring= " , datestring);
+            var dateobj = getLastDayOfMonth(datestring);
             data.addRow([dateobj, monthlyResolutions[key].resolutions ]);
                       
           }
@@ -234,6 +232,12 @@
         chart.draw(data, options);
 
         return;
+    }
+
+    function getLastDayOfMonth(monthString) {
+        const [year, month] = monthString.split('-').map(Number);
+        const lastDay = new Date(year, month, 0);
+        return lastDay;
     }
 
     function renderResolutionsBotPercent(doiResolutions) {


### PR DESCRIPTION
We are from CNRI. The data used to populate the resolutions chart has months and the number for the month is the number of resolutions that occurred in that month. Formerly the chart used the first day of the month for that but as a result hovering over points in the chart would show the previous month, at least in our time zone. This change uses the last day of the month local time and the data looks correct when you hover.